### PR TITLE
feat: minimal On This Day with Mastodon integration

### DIFF
--- a/components/CommitCard.vue
+++ b/components/CommitCard.vue
@@ -1,75 +1,29 @@
-<!--
-  @file CommitCard.vue
-  @description Git commit display card with repository, hash, message, and timestamp
-  @props sha: string - Git commit hash (short form)
-  @props message: string - Commit message
-  @props repo: string - Repository name
-  @props date: string - Commit timestamp (optional)
--->
 <template>
   <article class="commit-card group">
-    <div class="flex gap-3">
-      <!-- Git icon -->
-      <div
-        class="flex-shrink-0 w-10 h-10 rounded-full flex bg-green-50 dark:bg-green-950 items-center justify-center"
-      >
-        <svg
-          class="w-5 h-5 text-green-600 dark:text-green-400"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
-          />
-        </svg>
+    <div class="flex gap-2">
+      <!-- Icon -->
+      <div class="flex-shrink-0 pt-1">
+        <span class="text-zinc-400 dark:text-zinc-600 text-xs">G</span>
       </div>
 
       <div class="flex-grow min-w-0">
         <!-- Header -->
-        <div class="flex items-center gap-2 mb-2">
-          <span class="font-medium text-zinc-900 dark:text-zinc-100 text-sm">
-            {{ repo }}
-          </span>
+        <div class="flex items-center gap-2 mb-1 text-xs">
+          <time
+            v-if="date"
+            :datetime="date"
+            class="text-zinc-400 dark:text-zinc-500"
+          >
+            {{ formattedDate }}
+          </time>
           <span class="text-zinc-300 dark:text-zinc-700">·</span>
-          <code class="text-xs font-mono text-zinc-400 dark:text-zinc-500">
-            {{ sha }}
-          </code>
+          <span class="text-zinc-500 dark:text-zinc-400">{{ repo }}</span>
         </div>
 
         <!-- Commit message -->
-        <p
-          class="text-zinc-700 dark:text-zinc-300 text-[15px] leading-relaxed font-mono"
-        >
+        <p class="text-zinc-700 dark:text-zinc-300 text-sm leading-snug">
           {{ message }}
         </p>
-
-        <!-- Footer -->
-        <div
-          class="flex items-center gap-4 mt-2 text-xs text-zinc-400 dark:text-zinc-500"
-        >
-          <time v-if="date" :datetime="date">{{ formattedDate }}</time>
-          <a
-            v-if="sha && repo"
-            :href="`https://github.com/ejfox/${repo}/commit/${sha}`"
-            target="_blank"
-            rel="noopener"
-            class="ml-auto opacity-0 group-hover:opacity-100 transition-opacity duration-150 hover:text-zinc-600 dark:hover:text-zinc-300"
-          >
-            <svg
-              class="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-              />
-            </svg>
-          </a>
-        </div>
       </div>
     </div>
   </article>
@@ -101,7 +55,11 @@ const formattedDate = computed(() => {
 
 <style scoped>
 .commit-card {
-  @apply p-4 bg-white dark:bg-zinc-950 border rounded-xl;
-  @apply border-zinc-100 dark:border-zinc-900;
+  @apply py-3 px-0;
+  @apply border-b border-zinc-200 dark:border-zinc-800;
+}
+
+.commit-card:hover {
+  @apply bg-zinc-50/30 dark:bg-zinc-900/30;
 }
 </style>

--- a/components/MastodonCard.vue
+++ b/components/MastodonCard.vue
@@ -1,0 +1,101 @@
+<template>
+  <article class="mastodon-card group">
+    <div class="flex gap-2">
+      <!-- Icon -->
+      <div class="flex-shrink-0 pt-1">
+        <span class="text-zinc-400 dark:text-zinc-600 text-xs">M</span>
+      </div>
+
+      <div class="flex-grow min-w-0">
+        <!-- Header -->
+        <div class="flex items-center gap-1.5 mb-1 text-xs">
+          <time
+            v-if="date"
+            :datetime="date"
+            class="text-zinc-400 dark:text-zinc-500"
+          >
+            {{ formattedDate }}
+          </time>
+        </div>
+
+        <!-- Post text -->
+        <p
+          class="text-zinc-700 dark:text-zinc-300 text-sm leading-snug whitespace-pre-wrap break-words"
+        >
+          {{ text }}
+        </p>
+
+        <!-- Engagement -->
+        <div
+          v-if="favorites > 0 || reblogs > 0"
+          class="flex items-center gap-3 mt-2 text-xs text-zinc-400 dark:text-zinc-600"
+        >
+          <span v-if="favorites > 0">⭐ {{ favorites }}</span>
+          <span v-if="reblogs > 0">↻ {{ reblogs }}</span>
+        </div>
+      </div>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  id?: string
+  text: string
+  date?: string
+  url?: string
+  replyTo?: string | null
+  favorites?: number
+  reblogs?: number
+  visibility?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  id: undefined,
+  date: undefined,
+  url: undefined,
+  replyTo: undefined,
+  favorites: 0,
+  reblogs: 0,
+  visibility: 'public',
+})
+
+const formattedDate = computed(() => {
+  if (!props.date) return ''
+  try {
+    const d = new Date(props.date)
+    const now = new Date()
+    const diffDays = Math.floor(
+      (now.getTime() - d.getTime()) / (1000 * 60 * 60 * 24)
+    )
+
+    if (diffDays < 1) return 'today'
+    if (diffDays === 1) return 'yesterday'
+    if (diffDays < 7) return `${diffDays}d`
+    if (diffDays < 365) {
+      return d.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      })
+    }
+    return d.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  } catch {
+    return ''
+  }
+})
+</script>
+
+<style scoped>
+.mastodon-card {
+  @apply py-3 px-0;
+  @apply border-b border-zinc-200 dark:border-zinc-800;
+}
+
+.mastodon-card:hover {
+  @apply bg-zinc-50/30 dark:bg-zinc-900/30;
+}
+</style>

--- a/components/ScrobbleCard.vue
+++ b/components/ScrobbleCard.vue
@@ -1,58 +1,33 @@
-<!--
-  @file ScrobbleCard.vue
-  @description Last.fm scrobble display card showing play count and top tracks/artists
-  @props count: number - Total scrobble count
-  @props topTracks: string[] - Array of top track names
-  @props topArtists: string[] - Array of top artist names (optional)
-  @props date: string - Date of scrobbles (optional)
--->
 <template>
   <article class="scrobble-card">
-    <div class="flex gap-3">
-      <!-- Music icon -->
-      <div
-        class="flex-shrink-0 w-10 h-10 rounded-full flex bg-red-50 dark:bg-red-950 items-center justify-center"
-      >
-        <svg
-          class="w-5 h-5 text-red-500 dark:text-red-400"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"
-          />
-        </svg>
+    <div class="flex gap-2">
+      <!-- Icon -->
+      <div class="flex-shrink-0 pt-1">
+        <span class="text-zinc-400 dark:text-zinc-600 text-xs">♫</span>
       </div>
 
       <div class="flex-grow min-w-0">
         <!-- Header -->
-        <div class="flex items-baseline gap-2 mb-2">
-          <span class="font-medium text-zinc-900 dark:text-zinc-100 text-sm">
-            {{ count }} scrobbles
+        <div class="flex items-baseline gap-2 mb-1 text-xs">
+          <span class="text-zinc-400 dark:text-zinc-500">
+            {{ count }} plays
           </span>
           <span
             v-if="topArtists?.length"
-            class="text-zinc-400 dark:text-zinc-500 text-xs"
+            class="text-zinc-500 dark:text-zinc-400"
           >
             {{ topArtists.slice(0, 2).join(', ') }}
           </span>
         </div>
 
         <!-- Tracks -->
-        <div class="space-y-1">
+        <div class="space-y-0.5">
           <div
-            v-for="(track, i) in topTracks"
+            v-for="track in topTracks.slice(0, 3)"
             :key="track"
-            class="flex items-center gap-2 text-sm"
+            class="text-sm text-zinc-700 dark:text-zinc-300 truncate"
           >
-            <span
-              class="text-zinc-300 dark:text-zinc-700 text-xs font-mono w-4"
-            >
-              {{ i + 1 }}
-            </span>
-            <span class="text-zinc-600 dark:text-zinc-400 truncate">
-              {{ track }}
-            </span>
+            {{ track }}
           </div>
         </div>
       </div>
@@ -73,7 +48,11 @@ defineProps<Props>()
 
 <style scoped>
 .scrobble-card {
-  @apply p-4 bg-white dark:bg-zinc-950 border rounded-xl;
-  @apply border-zinc-100 dark:border-zinc-900;
+  @apply py-3 px-0;
+  @apply border-b border-zinc-200 dark:border-zinc-800;
+}
+
+.scrobble-card:hover {
+  @apply bg-zinc-50/30 dark:bg-zinc-900/30;
 }
 </style>

--- a/components/TweetCard.vue
+++ b/components/TweetCard.vue
@@ -1,128 +1,37 @@
-<!--
-  @file TweetCard.vue
-  @description Twitter-style tweet card with text, engagement stats, and link to original tweet
-  @props id: string - Tweet ID (optional)
-  @props text: string - Tweet text content
-  @props date: string - Tweet date (optional)
-  @props replyTo: string - Username being replied to (optional)
-  @props favorites: number - Favorite count (default: 0)
-  @props retweets: number - Retweet count (default: 0)
-  @props year: number - Year of tweet (optional)
--->
 <template>
   <article class="tweet-card group">
-    <div class="flex gap-3">
-      <!-- Avatar placeholder -->
-      <div
-        class="flex-shrink-0 w-10 h-10 rounded-full flex bg-zinc-200 dark:bg-zinc-800 items-center justify-center"
-      >
-        <span class="text-xs font-mono text-zinc-500 dark:text-zinc-400">
-          EJ
-        </span>
+    <div class="flex gap-2">
+      <!-- Icon -->
+      <div class="flex-shrink-0 pt-1">
+        <span class="text-zinc-400 dark:text-zinc-600 text-xs">𝕏</span>
       </div>
 
       <div class="flex-grow min-w-0">
         <!-- Header -->
-        <div class="flex items-center gap-2 mb-2">
-          <span class="font-medium text-zinc-900 dark:text-zinc-100 text-sm">
-            EJ Fox
-          </span>
-          <span class="text-zinc-400 dark:text-zinc-500 text-sm">@ejfox</span>
-          <span class="text-zinc-300 dark:text-zinc-700">·</span>
+        <div class="flex items-center gap-1.5 mb-1 text-xs">
           <time
             v-if="date"
             :datetime="date"
-            class="text-zinc-400 dark:text-zinc-500 text-sm"
+            class="text-zinc-400 dark:text-zinc-500"
           >
             {{ formattedDate }}
           </time>
         </div>
 
-        <!-- Reply indicator -->
-        <div
-          v-if="replyTo"
-          class="flex items-center gap-0.5 mb-2 text-xs text-zinc-400 dark:text-zinc-500"
-        >
-          <svg
-            class="w-3 h-3"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
-            />
-          </svg>
-          <span>Replying to @{{ replyTo }}</span>
-        </div>
-
         <!-- Tweet text -->
         <p
-          class="text-zinc-800 dark:text-zinc-200 text-[15px] leading-relaxed whitespace-pre-wrap break-words"
+          class="text-zinc-700 dark:text-zinc-300 text-sm leading-snug whitespace-pre-wrap break-words"
         >
           {{ text }}
         </p>
 
         <!-- Engagement -->
         <div
-          class="flex items-center gap-6 mt-4 text-xs text-zinc-400 dark:text-zinc-500"
+          v-if="favorites > 0 || retweets > 0"
+          class="flex items-center gap-3 mt-2 text-xs text-zinc-400 dark:text-zinc-600"
         >
-          <span v-if="retweets > 0" class="flex items-center gap-0.5.5">
-            <svg
-              class="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-              />
-            </svg>
-            {{ retweets }}
-          </span>
-          <span v-if="favorites > 0" class="flex items-center gap-0.5.5">
-            <svg
-              class="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-              />
-            </svg>
-            {{ favorites }}
-          </span>
-          <a
-            v-if="id"
-            :href="`https://twitter.com/ejfox/status/${id}`"
-            target="_blank"
-            rel="noopener"
-            class="ml-auto opacity-0 group-hover:opacity-100 transition-opacity duration-150 hover:text-zinc-600 dark:hover:text-zinc-300"
-          >
-            <svg
-              class="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-              />
-            </svg>
-          </a>
+          <span v-if="favorites > 0">♥ {{ favorites }}</span>
+          <span v-if="retweets > 0">↻ {{ retweets }}</span>
         </div>
       </div>
     </div>
@@ -180,7 +89,11 @@ const formattedDate = computed(() => {
 
 <style scoped>
 .tweet-card {
-  @apply p-4 bg-white dark:bg-zinc-950 border rounded-xl;
-  @apply border-zinc-100 dark:border-zinc-900;
+  @apply py-3 px-0;
+  @apply border-b border-zinc-200 dark:border-zinc-800;
+}
+
+.tweet-card:hover {
+  @apply bg-zinc-50/30 dark:bg-zinc-900/30;
 }
 </style>

--- a/pages/on-this-day.vue
+++ b/pages/on-this-day.vue
@@ -118,6 +118,22 @@
             />
           </template>
 
+          <!-- Mastodon Posts -->
+          <template v-if="yearData.mastodon?.length">
+            <MastodonCard
+              v-for="post in yearData.mastodon.filter((p) => !p.replyTo)"
+              :id="post.id"
+              :key="post.id"
+              :text="post.text"
+              :date="post.date"
+              :url="post.url"
+              :reply-to="post.replyTo"
+              :favorites="post.favorites"
+              :reblogs="post.reblogs"
+              :visibility="post.visibility"
+            />
+          </template>
+
           <!-- Scrobbles -->
           <template v-if="yearData.scrobbles?.length">
             <ScrobbleCard
@@ -149,7 +165,8 @@ const { tocTarget } = useTOC()
 const sourceIcons: Record<string, string> = {
   posts: 'P',
   tweets: 'X',
-  scrobbles: 'M',
+  mastodon: 'M',
+  scrobbles: '♫',
   commits: 'G',
 }
 
@@ -157,6 +174,7 @@ const sourceIcons: Record<string, string> = {
 const sourceLabels: Record<string, [string, string]> = {
   total_posts: ['post', 'posts'],
   total_tweets: ['tweet', 'tweets'],
+  total_mastodon: ['toot', 'toots'],
   total_scrobbles: ['year of music', 'years of music'],
   total_commits: ['commit', 'commits'],
 }

--- a/pages/on-this-day.vue
+++ b/pages/on-this-day.vue
@@ -1,5 +1,24 @@
 <template>
   <div class="max-w-3xl mx-auto px-4 py-12">
+    <!-- Year Navigation TOC -->
+    <ClientOnly>
+      <Teleport v-if="tocTarget" to="#nav-toc-container">
+        <div v-if="data?.years?.length" class="py-4">
+          <div class="text-xs font-mono text-zinc-400 mb-2">Years</div>
+          <ul class="space-y-1">
+            <li v-for="yearData in data.years" :key="yearData.year">
+              <a
+                :href="`#year-${yearData.year}`"
+                class="block py-1 text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+              >
+                <span class="font-mono tabular-nums">{{ yearData.year }}</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </Teleport>
+    </ClientOnly>
+
     <!-- Header -->
     <header class="mb-12">
       <h1 class="font-serif text-3xl mb-2">On This Day</h1>
@@ -28,7 +47,11 @@
 
     <!-- Timeline by year -->
     <div v-else class="space-y-6">
-      <section v-for="yearData in data.years" :key="yearData.year">
+      <section
+        v-for="yearData in data.years"
+        :id="`year-${yearData.year}`"
+        :key="yearData.year"
+      >
         <!-- Year header -->
         <div class="year-header">
           <span class="font-mono text-lg font-bold">{{ yearData.year }}</span>
@@ -120,6 +143,7 @@
 <script setup lang="ts">
 const route = useRoute()
 const router = useRouter()
+const { tocTarget } = useTOC()
 
 // Source type icons (easily extensible)
 const sourceIcons: Record<string, string> = {

--- a/scripts/build-on-this-day.mjs
+++ b/scripts/build-on-this-day.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * Build on-this-day JSON files from various data sources
+ * Aggregates tweets, mastodon posts, commits, scrobbles, and blog posts by date
+ *
+ * Usage: node scripts/build-on-this-day.mjs
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse } from 'csv-parse/sync'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const DATA_DIR = join(__dirname, '../data')
+const OUTPUT_DIR = join(DATA_DIR, 'on-this-day')
+
+// Ensure output directory exists
+if (!existsSync(OUTPUT_DIR)) {
+  mkdirSync(OUTPUT_DIR, { recursive: true })
+}
+
+function loadJSON(filename) {
+  try {
+    const path = join(DATA_DIR, filename)
+    if (!existsSync(path)) {
+      console.log(`⚠️  ${filename} not found, skipping`)
+      return null
+    }
+    return JSON.parse(readFileSync(path, 'utf-8'))
+  } catch (error) {
+    console.error(`Error loading ${filename}:`, error.message)
+    return null
+  }
+}
+
+function loadCSV(filename) {
+  try {
+    const path = join(DATA_DIR, filename)
+    if (!existsSync(path)) {
+      console.log(`⚠️  ${filename} not found, skipping`)
+      return null
+    }
+    const content = readFileSync(path, 'utf-8')
+    return parse(content, {
+      columns: true,
+      skip_empty_lines: true,
+      relax_quotes: true,
+      relax_column_count: true,
+    })
+  } catch (error) {
+    console.error(`Error loading ${filename}:`, error.message)
+    return null
+  }
+}
+
+function getDateKey(dateStr) {
+  const date = new Date(dateStr)
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${month}-${day}`
+}
+
+function buildOnThisDay() {
+  console.log('Building On This Day data...\n')
+
+  // Initialize data structure for each day of the year
+  const dayData = {}
+
+  // Load source data
+  const tweets = loadJSON('tweets.json')
+  const mastodonPosts = loadJSON('mastodon-posts.json')
+  const commits = loadJSON('github-commits.json')
+  const scrobbles = loadCSV('lastfm-scrobbles.csv')
+  const manifest = loadJSON('../content/processed/manifest-lite.json')
+
+  // Process tweets
+  if (tweets && Array.isArray(tweets)) {
+    console.log(`Processing ${tweets.length} tweets...`)
+    for (const tweet of tweets) {
+      if (!tweet.created_at) continue
+
+      const dateKey = getDateKey(tweet.created_at)
+      if (!dayData[dateKey]) dayData[dateKey] = {}
+      if (!dayData[dateKey].tweets) dayData[dateKey].tweets = []
+
+      const date = new Date(tweet.created_at)
+      dayData[dateKey].tweets.push({
+        id: tweet.id_str || tweet.id,
+        text: tweet.full_text || tweet.text,
+        year: date.getFullYear(),
+        date: tweet.created_at,
+        favorites: tweet.favorite_count || 0,
+        retweets: tweet.retweet_count || 0,
+        replyTo: tweet.in_reply_to_screen_name || null,
+      })
+    }
+  }
+
+  // Process Mastodon posts
+  if (mastodonPosts && Array.isArray(mastodonPosts)) {
+    console.log(`Processing ${mastodonPosts.length} mastodon posts...`)
+    for (const post of mastodonPosts) {
+      if (!post.date) continue
+
+      const dateKey = getDateKey(post.date)
+      if (!dayData[dateKey]) dayData[dateKey] = {}
+      if (!dayData[dateKey].mastodon) dayData[dateKey].mastodon = []
+
+      dayData[dateKey].mastodon.push({
+        id: post.id,
+        text: post.text,
+        year: post.year,
+        date: post.date,
+        url: post.url,
+        replyTo: post.replyTo,
+        favorites: post.favorites || 0,
+        reblogs: post.reblogs || 0,
+        visibility: post.visibility,
+      })
+    }
+  }
+
+  // Process commits
+  if (commits && Array.isArray(commits)) {
+    console.log(`Processing ${commits.length} commits...`)
+    for (const commit of commits) {
+      if (!commit.date) continue
+
+      const dateKey = getDateKey(commit.date)
+      if (!dayData[dateKey]) dayData[dateKey] = {}
+      if (!dayData[dateKey].commits) dayData[dateKey].commits = []
+
+      dayData[dateKey].commits.push({
+        sha: commit.sha,
+        message: commit.message,
+        year: commit.year,
+        date: commit.date,
+        repo: commit.repo,
+        repoUrl: commit.repoUrl,
+      })
+    }
+  }
+
+  // Process scrobbles
+  if (scrobbles && Array.isArray(scrobbles)) {
+    console.log(`Processing ${scrobbles.length} scrobbles...`)
+
+    // Group scrobbles by date
+    const scrobblesByDate = {}
+    for (const scrobble of scrobbles) {
+      if (!scrobble.date) continue
+
+      const dateKey = getDateKey(scrobble.date)
+      if (!scrobblesByDate[dateKey]) {
+        scrobblesByDate[dateKey] = []
+      }
+      scrobblesByDate[dateKey].push(scrobble)
+    }
+
+    // Aggregate per year per day
+    for (const [dateKey, dayScrobbles] of Object.entries(scrobblesByDate)) {
+      const byYear = {}
+
+      for (const scrobble of dayScrobbles) {
+        const date = new Date(scrobble.date)
+        const year = date.getFullYear()
+
+        if (!byYear[year]) {
+          byYear[year] = {
+            tracks: [],
+            artists: new Set(),
+          }
+        }
+
+        const trackName = `${scrobble.artist} - ${scrobble.track}`
+        byYear[year].tracks.push(trackName)
+        byYear[year].artists.add(scrobble.artist)
+      }
+
+      // Create summary for each year
+      if (!dayData[dateKey]) dayData[dateKey] = {}
+      if (!dayData[dateKey].scrobbles) dayData[dateKey].scrobbles = []
+
+      for (const [year, data] of Object.entries(byYear)) {
+        // Count track frequencies
+        const trackCounts = {}
+        for (const track of data.tracks) {
+          trackCounts[track] = (trackCounts[track] || 0) + 1
+        }
+
+        // Get top tracks
+        const topTracks = Object.entries(trackCounts)
+          .sort(([, a], [, b]) => b - a)
+          .slice(0, 10)
+          .map(([track]) => track)
+
+        dayData[dateKey].scrobbles.push({
+          year: parseInt(year),
+          date: `${year}-${dateKey}`,
+          count: data.tracks.length,
+          topTracks,
+          topArtists: Array.from(data.artists).slice(0, 3),
+        })
+      }
+    }
+  }
+
+  // Process blog posts
+  if (manifest && Array.isArray(manifest)) {
+    console.log(`Processing ${manifest.length} blog posts...`)
+    for (const post of manifest) {
+      if (!post.metadata?.date || post.draft) continue
+
+      const dateKey = getDateKey(post.metadata.date)
+      if (!dayData[dateKey]) dayData[dateKey] = {}
+      if (!dayData[dateKey].posts) dayData[dateKey].posts = []
+
+      const date = new Date(post.metadata.date)
+      dayData[dateKey].posts.push({
+        slug: post.slug,
+        title: post.metadata.title,
+        dek: post.metadata.dek || null,
+        year: date.getFullYear(),
+        date: post.metadata.date,
+      })
+    }
+  }
+
+  // Write files
+  console.log(`\nWriting ${Object.keys(dayData).length} day files...`)
+  for (const [dateKey, data] of Object.entries(dayData)) {
+    const filename = join(OUTPUT_DIR, `${dateKey}.json`)
+    writeFileSync(filename, JSON.stringify(data, null, 2))
+  }
+
+  // Create index
+  const index = Object.keys(dayData).sort()
+  const indexPath = join(DATA_DIR, 'on-this-day-index.json')
+  writeFileSync(indexPath, JSON.stringify(index, null, 2))
+
+  // Stats
+  const stats = {
+    totalDays: Object.keys(dayData).length,
+    totalTweets: Object.values(dayData).reduce(
+      (sum, day) => sum + (day.tweets?.length || 0),
+      0
+    ),
+    totalMastodon: Object.values(dayData).reduce(
+      (sum, day) => sum + (day.mastodon?.length || 0),
+      0
+    ),
+    totalCommits: Object.values(dayData).reduce(
+      (sum, day) => sum + (day.commits?.length || 0),
+      0
+    ),
+    totalScrobbles: Object.values(dayData).reduce(
+      (sum, day) => sum + (day.scrobbles?.length || 0),
+      0
+    ),
+    totalPosts: Object.values(dayData).reduce(
+      (sum, day) => sum + (day.posts?.length || 0),
+      0
+    ),
+  }
+
+  console.log('\n✅ Done!\n')
+  console.log('Stats:')
+  console.log(`  ${stats.totalDays} days with data`)
+  console.log(`  ${stats.totalTweets} tweets`)
+  console.log(`  ${stats.totalMastodon} mastodon posts`)
+  console.log(`  ${stats.totalCommits} commits`)
+  console.log(`  ${stats.totalScrobbles} scrobble summaries`)
+  console.log(`  ${stats.totalPosts} blog posts`)
+}
+
+buildOnThisDay()

--- a/scripts/export-mastodon.mjs
+++ b/scripts/export-mastodon.mjs
@@ -14,11 +14,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const OUTPUT_FILE = join(__dirname, '../data/mastodon-posts.json')
 
 const MASTODON_INSTANCE =
-  process.env.MASTODON_INSTANCE || 'https://mastodon.social'
-const MASTODON_TOKEN = process.env.MASTODON_TOKEN
+  process.env.MASTODON_API_URL ||
+  process.env.MASTODON_INSTANCE ||
+  'https://mastodon.social'
+const MASTODON_TOKEN =
+  process.env.MASTODON_ACCESS_TOKEN || process.env.MASTODON_TOKEN
 
 if (!MASTODON_TOKEN) {
-  console.error('Error: MASTODON_TOKEN environment variable is required')
+  console.error(
+    'Error: MASTODON_ACCESS_TOKEN environment variable is required'
+  )
   console.error(
     'Get a token from: ' + MASTODON_INSTANCE + '/settings/applications'
   )
@@ -42,7 +47,8 @@ async function fetchPosts() {
       })
 
       if (!verifyResponse.ok) {
-        throw new Error(`Failed to verify credentials: ${verifyResponse.statusText}`)
+        const errorText = await verifyResponse.text()
+        throw new Error(`Failed to verify credentials: ${verifyResponse.statusText} - ${errorText}`)
       }
 
       const account = await verifyResponse.json()
@@ -64,7 +70,8 @@ async function fetchPosts() {
       })
 
       if (!response.ok) {
-        throw new Error(`Failed to fetch posts: ${response.statusText}`)
+        const errorText = await response.text()
+        throw new Error(`Failed to fetch posts: ${response.statusText} - ${errorText}`)
       }
 
       const posts = await response.json()

--- a/scripts/export-mastodon.mjs
+++ b/scripts/export-mastodon.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Export Mastodon posts to JSON for on-this-day feature
+ * Uses Mastodon API to fetch all posts by user
+ *
+ * Usage: MASTODON_INSTANCE=https://mastodon.social MASTODON_TOKEN=xxx node scripts/export-mastodon.mjs
+ */
+
+import { writeFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const OUTPUT_FILE = join(__dirname, '../data/mastodon-posts.json')
+
+const MASTODON_INSTANCE =
+  process.env.MASTODON_INSTANCE || 'https://mastodon.social'
+const MASTODON_TOKEN = process.env.MASTODON_TOKEN
+
+if (!MASTODON_TOKEN) {
+  console.error('Error: MASTODON_TOKEN environment variable is required')
+  console.error(
+    'Get a token from: ' + MASTODON_INSTANCE + '/settings/applications'
+  )
+  process.exit(1)
+}
+
+async function fetchPosts() {
+  const allPosts = []
+  let maxId = null
+  let hasMore = true
+
+  console.log(`Fetching posts from ${MASTODON_INSTANCE}...`)
+
+  while (hasMore) {
+    try {
+      const url = new URL(`${MASTODON_INSTANCE}/api/v1/accounts/verify_credentials`)
+      const verifyResponse = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${MASTODON_TOKEN}`,
+        },
+      })
+
+      if (!verifyResponse.ok) {
+        throw new Error(`Failed to verify credentials: ${verifyResponse.statusText}`)
+      }
+
+      const account = await verifyResponse.json()
+      const accountId = account.id
+
+      // Fetch statuses
+      const statusUrl = new URL(
+        `${MASTODON_INSTANCE}/api/v1/accounts/${accountId}/statuses`
+      )
+      statusUrl.searchParams.set('limit', '40')
+      statusUrl.searchParams.set('exclude_replies', 'false')
+      statusUrl.searchParams.set('exclude_reblogs', 'true')
+      if (maxId) statusUrl.searchParams.set('max_id', maxId)
+
+      const response = await fetch(statusUrl, {
+        headers: {
+          Authorization: `Bearer ${MASTODON_TOKEN}`,
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch posts: ${response.statusText}`)
+      }
+
+      const posts = await response.json()
+
+      if (posts.length === 0) {
+        hasMore = false
+        break
+      }
+
+      for (const post of posts) {
+        const date = new Date(post.created_at)
+
+        // Strip HTML from content
+        const content = post.content
+          .replace(/<br\s*\/?>/gi, '\n')
+          .replace(/<\/?[^>]+(>|$)/g, '')
+          .replace(/&quot;/g, '"')
+          .replace(/&apos;/g, "'")
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>')
+          .replace(/&amp;/g, '&')
+
+        allPosts.push({
+          id: post.id,
+          text: content,
+          date: post.created_at,
+          year: date.getFullYear(),
+          month: date.getMonth() + 1,
+          day: date.getDate(),
+          url: post.url,
+          replyTo: post.in_reply_to_id,
+          favorites: post.favourites_count,
+          reblogs: post.reblogs_count,
+          visibility: post.visibility,
+        })
+      }
+
+      console.log(
+        `  Fetched ${posts.length} posts (total: ${allPosts.length})`
+      )
+
+      // Get the ID of the last post for pagination
+      maxId = posts[posts.length - 1].id
+
+      // Rate limit: Be nice to the server
+      await new Promise((r) => setTimeout(r, 1000))
+    } catch (error) {
+      console.error(`Error fetching posts:`, error.message)
+      hasMore = false
+    }
+  }
+
+  return allPosts
+}
+
+async function main() {
+  console.log('Mastodon Post Export')
+  console.log('====================\n')
+
+  const posts = await fetchPosts()
+
+  // Sort by date
+  posts.sort((a, b) => new Date(b.date) - new Date(a.date))
+
+  // Write to file
+  writeFileSync(OUTPUT_FILE, JSON.stringify(posts, null, 2))
+
+  // Stats
+  const years = [...new Set(posts.map((p) => p.year))].sort((a, b) => b - a)
+  const repliesCount = posts.filter((p) => p.replyTo).length
+  const postsCount = posts.length - repliesCount
+
+  console.log(`\nExported ${posts.length} posts`)
+  console.log(`  ${postsCount} original posts`)
+  console.log(`  ${repliesCount} replies`)
+  console.log(`Years: ${years.join(', ')}`)
+  console.log(`Output: ${OUTPUT_FILE}`)
+}
+
+main().catch(console.error)


### PR DESCRIPTION
## Summary
- Minimal, data-dense On This Day design with Tuftian principles
- Filter out RTs and replies from tweets
- Year navigation sidebar using TOC teleport
- Mastodon integration (waiting for API token with read:statuses scope)
- Build script to aggregate tweets, mastodon, commits, scrobbles, blog posts by date

## Changes
- **Cards**: Removed backgrounds/borders, changed to simple bottom borders with text icons
- **TweetCard**: Minimal design, filter RTs/replies
- **CommitCard**: Minimal design with 'G' icon
- **ScrobbleCard**: Top 3 tracks, '♫' icon
- **MastodonCard**: New component for mastodon posts (minimal design)
- **On This Day page**: Year sidebar navigation, mastodon section, filtered content
- **export-mastodon.mjs**: Fetch mastodon posts from API with enhanced error messages
- **build-on-this-day.mjs**: Aggregate all sources into daily JSON files

## Testing
- Cards render with minimal styling ✅
- Year navigation works ✅
- Mastodon export script needs token with `read:statuses` scope ⏳

## Next Steps
1. Update Mastodon token at https://mastodon.social/settings/applications
2. Add `read:statuses` scope (or full `read` scope)
3. Run `MASTODON_ACCESS_TOKEN=xxx node scripts/export-mastodon.mjs`
4. Run `node scripts/build-on-this-day.mjs` to regenerate aggregated data

🤖 Generated with [Claude Code](https://claude.com/claude-code)